### PR TITLE
all targets are expecting an object, not an array of objects

### DIFF
--- a/lib/Bristol.js
+++ b/lib/Bristol.js
@@ -60,7 +60,7 @@ Bristol.prototype.addTarget = function(target, options) {
 	if (typeof target === 'string')
 		target = require('./targets/' + target);
 	var targetObj = {
-		log: target.bind(target, options),
+		log: target.bind(target, options || {}),
 		formatter: DEFAULT_FORMATTER.bind(this, [{}]),
 		blacklist: {},
 		whitelist: {},


### PR DESCRIPTION
I believe this was just a typo when calling .bind
