### PR TITLE
loggly target

### DIFF
--- a/lib/targets/loggly.js
+++ b/lib/targets/loggly.js
@@ -1,0 +1,58 @@
+/*
+ * Bristol
+ * Copyright 2014 Tom Frost
+ */
+
+var loggly = require('loggly');
+
+var logglyClients = {};
+
+function getLogglyClient(token, subdomain, username, password, tags) {
+	var cid = token + subdomain;
+
+	if (!logglyClients[cid]) {
+		var opts = {
+			token: token,
+			subdomain: subdomain,
+			auth: {
+				username: username,
+				password: password
+			}
+		};
+		if (tags) {
+			if (!Array.isArray(tags)) {
+				tags = [tags];
+			}
+			opts.tags = tags;
+		}
+		logglyClients[cid] = loggly.createClient(opts);
+	}
+
+	return logglyClients[cid];
+}
+
+/**
+ * Pushes a log message to loggly
+ * @param {Object} options  Map of options to customize Loggly
+ * @param {string} options.token Your loggly token
+ * @param {string} options.subdomain Loggly subdomain
+ * @param {string} options.username Loggly username
+ * @param {string} options.password Loggly password
+ * @param {Array|string} options.tags Global Loggly tags
+ * @param {string} severity The severity of the log message
+ * @param {Date} date The date of the log message
+ * @param {string} message The message to be pushed to loggly
+ */
+function log(options, severity, date, message) {
+	var client = getLogglyClient(options.token, options.subdomain, options.username, options.password, options.tags),
+		tags = options.tags || null;
+
+	client.log(message, tags, function(err, result) {
+		if (err) {
+			console.log("Error publishing log message to Loggly: " + err +
+				"Message was: " + message);
+		}
+	});
+}
+
+module.exports = log;

--- a/package.json
+++ b/package.json
@@ -37,7 +37,8 @@
     "blanket": "~1.1.5",
     "grunt-mocha-test": "~0.8.2",
     "grunt-env": "~0.4.1",
-    "travis-cov": "~0.2.4"
+    "travis-cov": "~0.2.4",
+    "loggly": "^1.0.4"
   },
   "dependencies": {
     "moment": "~2.5.1"

--- a/test/targets/loggly.js
+++ b/test/targets/loggly.js
@@ -1,0 +1,19 @@
+/*
+ * Bristol
+ * Copyright 2014 Tom Frost
+ */
+
+var should = require('should'),
+	logglyTarget = require('../../lib/targets/loggly');
+
+
+
+describe("Loggly Target", function() {
+	(function(){
+		logglyTarget({token: 'Your-Token', username: 'Your-Username', password: 'Your-Password', subdomain: 'Your-subdomain'},'debug', new Date(), 'foo')
+	}).should.not.throw();
+
+	(function(){
+		logglyTarget({},'debug', new Date(), 'foo')
+	}).should.throw();
+});


### PR DESCRIPTION
Followed the same pattern as your SNS target.

Tests are...gross.  Loggly does a nice job of not failing with bad Auth (this is actually probably a bad thing on their part).

Added loggly module as a dev dependency only.  Since targets are lazy loaded I feel the onus should be on the user of the target to include the dependency.
