### PR TITLE
Fix package.json, Fix syslog formatting to use day-of-month instead of day-of-week

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "bristol",
   "version": "0.3.3",
   "description": "Insanely configurable logging for Node.js",
-  "main": "lib/Bristol.js",
+  "main": "src/Bristol.js",
   "scripts": {
     "lint": "eslint src test",
     "test": "npm run lint && npm run test-cov && npm run check-cov",

--- a/src/formatters/syslog.js
+++ b/src/formatters/syslog.js
@@ -60,7 +60,7 @@ const getLogVal = (val) => {
 module.exports = (options, severity, date, elems) => {
   const sevKey = options.severityKey || DEFAULT_SEVERITY_KEY
   const obj = {}
-  const dateStr = moment(date).format('MMM d HH:mm:ss')
+  const dateStr = moment(date).format('MMM D HH:mm:ss')
   let line = `${dateStr} ${os.hostname()} ${process.title} [${process.pid}]:`
   let msg = ''
   obj[sevKey] = severity


### PR DESCRIPTION
As it is, the `syslog` formatter uses `d` instead of `D`, which will log the day of the week instead of the day of the month, giving us nonsense like:

`Aug 0 05:38:31 localhost node /var/www/project/index.js[5798]: severity=warn file=/var/www/project/file.js line=27 hostname=localhost userAgent="Mozilla/5.0 (X11; CrOS x86_64 8350.68.0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/52.0.2743.116 Safari/537.36" message="test" data=null now=19630.170000000002 userTime=2016-08-27T22:39:01.440-07:00 state=null`
