### PR TITLE
Adding logUtil export for convenience

### DIFF
--- a/src/Bristol.js
+++ b/src/Bristol.js
@@ -364,3 +364,4 @@ class Bristol extends events.EventEmitter {
 
 module.exports = new Bristol()
 module.exports.Bristol = Bristol
+module.exports._logUtil = logUtil


### PR DESCRIPTION
I have a use-case where I need to write my own custom JSON formatter based on one one provided by Bristol. I'd like to use the same utilities so I am proposing adding an export.