### PR TITLE
Fixing main file location

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "bristol",
   "version": "0.3.3",
   "description": "Insanely configurable logging for Node.js",
-  "main": "lib/Bristol.js",
+  "main": "src/Bristol.js",
   "scripts": {
     "lint": "eslint src test",
     "test": "npm run lint && npm run test-cov && npm run check-cov",


### PR DESCRIPTION
The `lib` directory does not exist. Everything lives in `src`.
