### PR TITLE
Fixing origin when wrapping Bristol (fixes #29)

### DIFF
--- a/src/Bristol.js
+++ b/src/Bristol.js
@@ -249,10 +249,9 @@ class Bristol extends events.EventEmitter {
    * @private
    */
   _processStack(stack, bristolFileName) {
-    let lastIndex = 0
-    for (let i = stack.length - 1; i >= 0; i--) {
-      if (stack[i].getFileName() === bristolFileName) {
-        lastIndex = i
+    let lastIndex = stack.length - 1
+    for (; lastIndex >= 0; lastIndex--) {
+      if (stack[lastIndex].getFileName() === bristolFileName) {
         break
       }
     }

--- a/src/Bristol.js
+++ b/src/Bristol.js
@@ -237,20 +237,33 @@ class Bristol extends events.EventEmitter {
   _getOrigin() {
     Error.prepareStackTrace = arrayPrepareStackTrace
     const stack = (new Error()).stack
+    Error.prepareStackTrace = originalPrepareStackTrace
+    return this._processStack(stack, __filename)
+  }
+
+  /**
+   * Processes the stack trace of the Bristol log call, excluding wrapping functions.
+   * @returns {null|{file, line}} An object containing the file path and line
+   *   number of the originating Bristol call, or null if this information
+   *   cannot be found.
+   * @private
+   */
+  _processStack(stack, bristolFileName) {
     let lastIndex = 0
     for (let i = stack.length - 1; i >= 0; i--) {
-      if (stack[i].getFileName() === __filename) {
+      if (stack[i].getFileName() === bristolFileName) {
         lastIndex = i
         break
       }
     }
     const line = stack[lastIndex + 1]
-    let origin = {
-      file: line.getFileName(),
-      line: line.getLineNumber().toString()
+    if (line) {
+      return {
+        file: line.getFileName(),
+        line: line.getLineNumber().toString()
+      }
     }
-    Error.prepareStackTrace = originalPrepareStackTrace
-    return origin
+    return null
   }
 
   /**

--- a/src/Bristol.js
+++ b/src/Bristol.js
@@ -238,13 +238,11 @@ class Bristol extends events.EventEmitter {
     Error.prepareStackTrace = arrayPrepareStackTrace
     const stack = (new Error()).stack
     const lastIndex = stack.map(s => s.getFileName()).lastIndexOf(__filename)
-
     const line = stack[lastIndex + 1]
     let origin = {
       file: line.getFileName(),
       line: line.getLineNumber().toString()
     }
-
     Error.prepareStackTrace = originalPrepareStackTrace
     return origin
   }

--- a/src/Bristol.js
+++ b/src/Bristol.js
@@ -237,17 +237,14 @@ class Bristol extends events.EventEmitter {
   _getOrigin() {
     Error.prepareStackTrace = arrayPrepareStackTrace
     const stack = (new Error()).stack
-    let origin = null
-    for (let i = 1; i < stack.length; i++) {
-      const file = stack[i].getFileName()
-      if (file !== __filename) {
-        origin = {
-          file,
-          line: stack[i].getLineNumber().toString()
-        }
-        break
-      }
+    const lastIndex = stack.map(s => s.getFileName()).lastIndexOf(__filename)
+
+    const line = stack[lastIndex + 1]
+    let origin = {
+      file: line.getFileName(),
+      line: line.getLineNumber().toString()
     }
+
     Error.prepareStackTrace = originalPrepareStackTrace
     return origin
   }

--- a/src/Bristol.js
+++ b/src/Bristol.js
@@ -237,7 +237,13 @@ class Bristol extends events.EventEmitter {
   _getOrigin() {
     Error.prepareStackTrace = arrayPrepareStackTrace
     const stack = (new Error()).stack
-    const lastIndex = stack.map(s => s.getFileName()).lastIndexOf(__filename)
+    let lastIndex = 0
+    for (let i = stack.length - 1; i >= 0; i--) {
+      if (stack[i].getFileName() === __filename) {
+        lastIndex = i
+        break
+      }
+    }
     const line = stack[lastIndex + 1]
     let origin = {
       file: line.getFileName(),

--- a/test/src/Bristol.js
+++ b/test/src/Bristol.js
@@ -40,6 +40,50 @@ describe('Bristol', () => {
       origin.should.have.property('line').and.be.a.string
     })
   })
+  describe('processStack', () => {
+    class MockStackLine {
+      constructor(file, line) {
+        this.file = file
+        this.line = line
+      }
+      getFileName() {
+        return this.file
+      }
+      getLineNumber() {
+        return this.line
+      }
+    }
+    it('gets the correct line for a normal call', () => {
+      const stack = [
+        new MockStackLine('Bristol.js', '202'),
+        new MockStackLine('caller.js', '6')
+      ]
+      const origin = log._processStack(stack, 'Bristol.js')
+      origin.should.have.property('file').and.eql('caller.js')
+      origin.should.have.property('line').and.be.a.string
+    })
+    it('gets the correct line for a wrapped call', () => {
+      const stack = [
+        new MockStackLine('wrapper.js', '2'),
+        new MockStackLine('Bristol.js', '202'),
+        new MockStackLine('caller.js', '6')
+      ]
+      const origin = log._processStack(stack, 'Bristol.js')
+      origin.should.have.property('file').and.eql('caller.js')
+      origin.should.have.property('line').and.be.a.string
+    })
+    it('gets the correct line for a wrapped call with repeated intermediates', () => {
+      const stack = [
+        new MockStackLine('wrapper.js', '2'),
+        new MockStackLine('Bristol.js', '202'),
+        new MockStackLine('Bristol.js', '202'),
+        new MockStackLine('caller.js', '6')
+      ]
+      const origin = log._processStack(stack, 'Bristol.js')
+      origin.should.have.property('file').and.eql('caller.js')
+      origin.should.have.property('line').and.be.a.string
+    })
+  })
   describe('targets', () => {
     it('returns a config chain with all properties', () => {
       const conf = b.addTarget(() => {})


### PR DESCRIPTION
Fix from issue #29.

The solution proposed in the issue did not work out because of cases where there are multiple callsites in the logger itself, meaning that `index + 1` would sometimes still reference the Bristol logger file.

For example, the stack from one of the mocha tests:
```
0:"/Users/Mark/projects/Bristol/src/Bristol.js"
1:"/Users/Mark/projects/Bristol/src/Bristol.js"
2:"/Users/Mark/projects/Bristol/src/Bristol.js"
3:"/Users/Mark/projects/Bristol/test/src/Bristol.js"
4:"/Users/Mark/projects/Bristol/node_modules/mocha/lib/runnable.js"
5:"/Users/Mark/projects/Bristol/node_modules/mocha/lib/runnable.js"
6:"/Users/Mark/projects/Bristol/node_modules/mocha/lib/runner.js"
7:"/Users/Mark/projects/Bristol/node_modules/mocha/lib/runner.js"
8:"/Users/Mark/projects/Bristol/node_modules/mocha/lib/runner.js"
9:"/Users/Mark/projects/Bristol/node_modules/mocha/lib/runner.js"
10:"/Users/Mark/projects/Bristol/node_modules/mocha/lib/runner.js"
11:"/Users/Mark/projects/Bristol/node_modules/mocha/lib/runner.js"
12:"timers.js"
13:"timers.js"
14:"timers.js"
```

The fix was just to look for the last occurrence of the Bristol logger file.