### PR TITLE
WIP: Benchmarks of formatters

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "lint": "eslint src test",
     "test": "npm run lint && npm run test-cov && npm run check-cov",
+    "bench": "node -r ./test/setup.js ./test/bench/formatters/json.js",
     "mocha": "mocha",
     "test-cov": "istanbul cover _mocha",
     "check-cov": "istanbul check-coverage --statements 90 --functions 90 --branches 70 --lines 90"
@@ -24,6 +25,7 @@
   "author": "Tom Shawver <tom@frosteddesign.com>",
   "license": "MIT",
   "devDependencies": {
+    "benchmark": "^2.1.3",
     "chai": "^3.5.0",
     "chai-as-promised": "^6.0.0",
     "eslint": "^3.12.2",

--- a/test/bench/formatters/json.js
+++ b/test/bench/formatters/json.js
@@ -1,0 +1,20 @@
+'use strict'
+
+const { Suite } = require('benchmark')
+const suite = new Suite()
+
+const json = require('src/formatters/json')
+
+const time = new Date()
+const error = new Error('blerg')
+const elems = [
+  { a: 'b', c: 'd', e: { hello: 'world' } },
+  { arg: 1, error: error, blerg: new Date() },
+  { f: true, g: ['h', 5, 'i', { j: 'k' }] }
+]
+
+suite.add('json formatter', function() {
+  json({}, 'debug', time, elems)
+}).on('cycle', function(event) {
+  console.log(String(event.target))
+}).run()


### PR DESCRIPTION
Here's a very crude and probably incorrect benchmark test for the json formatter.

```sh
$ npm run bench

> bristol@0.3.3 bench ~/Bristol
> node -r ./test/setup.js ./test/bench/formatters/json.js

json formatter x 62,879 ops/sec ±0.94% (89 runs sampled)
```

I want to add benchmarks to all the formatters and get a baseline of performance for issue #35 to compare the slowdown of doing a safer "stringifying" of messages.
