### PR TITLE
reuse the latest Error.prepareStackTrace instead of the original one

### DIFF
--- a/src/Bristol.js
+++ b/src/Bristol.js
@@ -11,7 +11,6 @@ const DEFAULT_FORMATTER = 'json'
 const logUtil = require('./logUtil')
 const events = require('events')
 
-const originalPrepareStackTrace = Error.prepareStackTrace
 const arrayPrepareStackTrace = (err, stack) => { return stack }
 
 /**
@@ -235,9 +234,10 @@ class Bristol extends events.EventEmitter {
    * @private
    */
   _getOrigin() {
+    const latestPrepareStackTrace = Error.prepareStackTrace
     Error.prepareStackTrace = arrayPrepareStackTrace
     const stack = (new Error()).stack
-    Error.prepareStackTrace = originalPrepareStackTrace
+    Error.prepareStackTrace = latestPrepareStackTrace
     return this._processStack(stack, __filename)
   }
 


### PR DESCRIPTION
In our app, we change the Error.prepareStackTrace to suit our needs.

Once we started using Bristol, which is awesome by the way, we started to have erratic stack traces. Our debugging revealed that Bristol was replacing our method with the original one, leaving us with vanilla stack traces.

So, in order to use Bristol, we had to make that change. We'd be more than happy to keep using your version instead of our fork, if you make us the honour to include that change in the npm version.