### PR TITLE
Fix invalid handling of dates (#47)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 .idea
+.vscode
 *.iml
 
 coverage
 node_modules
+yarn.lock

--- a/src/Bristol.js
+++ b/src/Bristol.js
@@ -142,7 +142,7 @@ class Bristol extends events.EventEmitter {
     args[0] = logUtil.safeMerge(this._getOrigin(), this._getGlobals())
     for (let i = 0; i < args.length; i++) {
       const arg = this._transform(args[i])
-      if (typeof arg === 'object' && !(arg instanceof Error)) {
+      if (typeof arg === 'object' && !(arg instanceof Error) && !(arg instanceof Date)) {
         logUtil.safeMerge(objArgs, arg)
       } else {
         logElems.push(arg)

--- a/test/src/Bristol.js
+++ b/test/src/Bristol.js
@@ -181,17 +181,10 @@ describe('Bristol', () => {
       b.addTarget((opts, sev, date, msg) => {
         res.msg = msg
       }).withFormatter((opts, sev, date, elems) => {
-        res.opts = opts
-        res.sev = sev
-        res.date = date
         res.elems = elems
         return 'foo'
       }, { cow: 'moo' })
       b.trace('hello', dateArg, 'world')
-      res.should.have.property('msg').and.eql('foo')
-      res.should.have.property('opts').and.include({cow: 'moo'})
-      res.should.have.property('sev').and.eql('trace')
-      res.should.have.property('date').and.be.instanceof(Date)
       res.should.have.property('elems').and.be.an.Array
       res.elems.length.should.be.above(1)
       res.elems[0].should.eql('hello')

--- a/test/src/Bristol.js
+++ b/test/src/Bristol.js
@@ -175,6 +175,29 @@ describe('Bristol', () => {
       res.should.have.property('elems').and.be.an.Array
       res.elems.length.should.be.above(1)
     })
+    it('passes dates to formatter', () => {
+      const res = {}
+      const dateArg = new Date(99999)
+      b.addTarget((opts, sev, date, msg) => {
+        res.msg = msg
+      }).withFormatter((opts, sev, date, elems) => {
+        res.opts = opts
+        res.sev = sev
+        res.date = date
+        res.elems = elems
+        return 'foo'
+      }, { cow: 'moo' })
+      b.trace('hello', dateArg, 'world')
+      res.should.have.property('msg').and.eql('foo')
+      res.should.have.property('opts').and.include({cow: 'moo'})
+      res.should.have.property('sev').and.eql('trace')
+      res.should.have.property('date').and.be.instanceof(Date)
+      res.should.have.property('elems').and.be.an.Array
+      res.elems.length.should.be.above(1)
+      res.elems[0].should.eql('hello')
+      res.elems[1].should.eql(dateArg)
+      res.elems[2].should.eql('world')
+    })
     it('logs to multiple targets', () => {
       let one = 0
       let two = 0


### PR DESCRIPTION
Fixes #47 by checking whether the element is `instanceof Date`.

The problem was that `typeof elem` would be `object` for `Date`s, which Bristol would then attempt to merge.